### PR TITLE
add --first-heading argument for latex backend

### DIFF
--- a/src/cmarkit_latex.mli
+++ b/src/cmarkit_latex.mli
@@ -21,7 +21,18 @@ val of_doc : ?backend_blocks:bool -> Cmarkit.Doc.t -> string
 
 (** {1:renderer Renderer} *)
 
-val renderer : ?backend_blocks:bool -> unit -> Cmarkit_renderer.t
+type heading =
+    | Part
+    | Chapter
+    | Section
+    | Subsection
+(** The type of headings. *)
+
+val heading_of_string : string -> heading option
+
+val pp_heading : Format.formatter -> heading -> unit
+
+val renderer : ?backend_blocks:bool -> ?first_heading:heading -> unit -> Cmarkit_renderer.t
 (** [renderer] is a default L{^A}T{_E}X renderer. This renders
     the strict CommonMark abstract syntax tree and the supported
     Cmarkit {{!Cmarkit.extensions}extensions}.
@@ -35,7 +46,10 @@ val renderer : ?backend_blocks:bool -> unit -> Cmarkit_renderer.t
     {ul
     {- [backend_blocks], if [true], code blocks with language [=latex]
        are written verbatim in the output and any other code block whose
-       langage starts with [=] is dropped. Defaults to [false].}}
+       langage starts with [=] is dropped. Defaults to [false].}
+    {- [first_heading], the first heading kind to use. Defaults to
+       [Section].}
+    }
 
     See {{!Cmarkit_renderer.example}this example} to extend or
     selectively override the renderer. *)


### PR DESCRIPTION
Hi,

If someone wants to use `cmarkit` to write a latex document using the `book` class (a PhD thesis for instance), one level of markdown is unused, because we have the following correspondence:

- `#` -> `section`
- `##` -> `subsection`
- `###` -> `subsubsection`
- `####` -> `paragraph`
- `#####` -> `subparagraph`
- `######` -> `subparagraph`

In the book class, you have two more kinds of headings: `part` and `chapter`. Thus, it is possible to use the following mapping:

- `#` -> `chapter`
- `##` -> `section`
- `###` -> `subsection`
- `####` -> `subsubsection`
- `#####` -> `paragraph`
- `######` -> `subparagraph`

You don't loose the ability to write anything and it is more convenient as it saves some ugly `=latex` blocks. You still have to use them for `part` but you usually don't have that many.

I implemented it in a quick and dirty way (the naming and the documentation are probably not good enough), but if you're willing to accept such a change, I can spend more time on it.

Let me know what you think.