### PR TITLE
Decrease ocaml lowerbound to 4.08

### DIFF
--- a/opam
+++ b/opam
@@ -30,7 +30,7 @@ homepage: "https://erratique.ch/software/cmarkit"
 doc: "https://erratique.ch/software/cmarkit/doc"
 bug-reports: "https://github.com/dbuenzli/cmarkit/issues"
 depends: [
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}


### PR DESCRIPTION
while working with markdown generation for odoc https://github.com/ocaml/odoc/pull/1341, maintainers raised the concern that the minimum ocaml version they support in ocaml.org is 4.08. I discovered that 4.14 isn't necessary to build cmarkit, so lowering the bound might make sense.

A PR on opam-repository updating previous versions might make sense as well. wdyt?