### PR TITLE
Fix locations of block quotes

### DIFF
--- a/src/cmarkit.ml
+++ b/src/cmarkit.ml
@@ -1980,13 +1980,17 @@ module Block_struct = struct
 
   let match_and_accept_block_quote p =
     (* https://spec.commonmark.org/current/#block-quote-marker *)
-    if end_of_line p || p.i.[p.current_char] <> '>' then false else
+    if end_of_line p || p.i.[p.current_char] <> '>' then Match.Nomatch else
+    let marker_span =
+      current_line_span p ~first:p.current_char ~last:(p.current_char+1)
+    in
     let next_is_blank =
       let next = p.current_char + 1 in
       next <= p.current_line_last_char && Ascii.is_blank p.i.[next]
     in
     let count = if next_is_blank then (* we eat a space *) 2 else 1 in
-    accept_cols ~count p; true
+    accept_cols ~count p;
+    Match.Block_quote_line marker_span
 
   let accept_list_marker_and_indent p ~marker_size ~last =
     (* Returns min indent after marker for list item  *)
@@ -2056,7 +2060,7 @@ module Block_struct = struct
   type paragraph = { maybe_ref : bool; lines : line_span list }
 
   type t =
-  | Block_quote of Layout.indent * t list
+  | Block_quote of Layout.indent * t list * line_span (* loc of initial marker *)
   | Blank_line of space_pad * line_span
   | Code_block of code_block
   | Heading of heading
@@ -2322,7 +2326,8 @@ module Block_struct = struct
       Html_block { h with end_cond = None } :: bs
 
   let rec end_doc p = function
-  | Block_quote (indent, bq) :: bs -> Block_quote (indent, end_doc p bq) :: bs
+  | Block_quote (indent, bq, marker) :: bs ->
+      Block_quote (indent, end_doc p bq, marker) :: bs
   | List list :: bs -> close_list p list bs
   | Paragraph par :: bs -> close_paragraph p par bs
   | Code_block (`Indented ls) :: bs -> close_indented_code_block p ls bs
@@ -2345,7 +2350,8 @@ module Block_struct = struct
       (* Early dispatch shaves a few ms but may not be worth doing vs
          testing all the cases in sequences.  *)
       | '>' ->
-          if match_and_accept_block_quote p then Match.Block_quote_line else
+          let r = match_and_accept_block_quote p in
+          if r <> Nomatch then r else
           Paragraph_line
       | '=' when not no_setext ->
           let r = Match.setext_heading_underline p.i ~last ~start in
@@ -2412,7 +2418,8 @@ module Block_struct = struct
   let rec add_open_blocks_with_line_class p ~indent_start ~indent bs = function
   | Match.Blank_line -> blank_line p :: bs
   | Indented_code_block_line -> indented_code_block p :: bs
-  | Block_quote_line -> Block_quote (indent, add_open_blocks p []) :: bs
+  | Block_quote_line marker ->
+      Block_quote (indent, add_open_blocks p [], marker) :: bs
   | Thematic_break_line last -> thematic_break p ~indent ~last :: bs
   | List_marker_line m -> list p ~indent m bs
   | Atx_heading_line (level, after_open, first_content, last_content) ->
@@ -2496,8 +2503,9 @@ module Block_struct = struct
         add_paragraph_line p ~indent_start par bs
     | Blank_line ->
         blank_line p :: close_paragraph p par bs
-    | Block_quote_line ->
-        Block_quote (indent, add_open_blocks p []) :: (close_paragraph p par bs)
+    | Block_quote_line marker ->
+        Block_quote (indent, add_open_blocks p [], marker)
+        :: (close_paragraph p par bs)
     | Setext_underline_line (level, last_underline) ->
         let bs = close_paragraph p par bs in
         begin match bs with
@@ -2568,10 +2576,10 @@ module Block_struct = struct
 
   let rec try_lazy_continuation p ~indent_start = function
   | Paragraph par :: bs -> Some (add_paragraph_line p ~indent_start par bs)
-  | Block_quote (indent, bq) :: bs ->
+  | Block_quote (indent, bq, marker) :: bs ->
       begin match try_lazy_continuation p ~indent_start bq with
       | None -> None
-      | Some bq -> Some (Block_quote (indent, bq) :: bs)
+      | Some bq -> Some (Block_quote (indent, bq, marker) :: bs)
       end
   | List l :: bs ->
       let i = List.hd l.items in
@@ -2593,19 +2601,24 @@ module Block_struct = struct
         let bs = Ext_table (ind, rows) :: bs in
         add_open_blocks_with_line_class p ~indent ~indent_start bs ltype
 
-  let rec try_add_to_block_quote p indent_layout bq bs =
+  let rec try_add_to_block_quote p indent_layout bq marker bs =
     let indent_start = p.current_char and indent = current_indent p in
     match match_line_type ~indent ~no_setext:true p with
-    | Block_quote_line -> Block_quote (indent_layout, add_line p bq) :: bs
+    | Block_quote_line _ ->
+        Block_quote (indent_layout, add_line p bq, marker) :: bs
     | (Indented_code_block_line (* Looks like a *) | Paragraph_line) as ltype ->
         begin match try_lazy_continuation p ~indent_start bq with
-        | Some bq -> Block_quote (indent_layout, bq) :: bs
+        | Some bq -> Block_quote (indent_layout, bq, marker) :: bs
         | None ->
-            let bs = Block_quote (indent_layout, close_last_block p bq) :: bs in
+            let bs =
+              Block_quote (indent_layout, close_last_block p bq, marker) :: bs
+            in
             add_open_blocks_with_line_class p ~indent ~indent_start bs ltype
         end
     | ltype ->
-        let bs = Block_quote (indent_layout, close_last_block p bq) :: bs in
+        let bs =
+          Block_quote (indent_layout, close_last_block p bq, marker) :: bs
+        in
         add_open_blocks_with_line_class p ~indent ~indent_start bs ltype
 
   and try_add_to_footnote p fn_indent label blocks bs =
@@ -2675,7 +2688,7 @@ module Block_struct = struct
   | List list :: bs -> try_add_to_list_item p list bs
   | Code_block (`Indented ls) :: bs -> try_add_to_indented_code_block p ls bs
   | Code_block (`Fenced f) :: bs -> try_add_to_fenced_code_block p f bs
-  | Block_quote (ind, bq) :: bs -> try_add_to_block_quote p ind bq bs
+  | Block_quote (ind, bq, marker) :: bs -> try_add_to_block_quote p ind bq marker bs
   | Html_block html :: bs -> try_add_to_html_block p html bs
   | Ext_table (ind, rows) :: bs -> try_add_to_table p ind rows bs
   | Ext_footnote (i, l, blocks) :: bs -> try_add_to_footnote p i l blocks bs
@@ -2852,7 +2865,7 @@ let block_struct_to_table p indent rows =
   let meta = meta_of_spans p ~first ~last in
   Block.Ext_table ({ indent; col_count; rows }, meta)
 
-let rec block_struct_to_block_quote p indent bs =
+let rec block_struct_to_block_quote p indent marker bs =
   let add_block p acc b = block_struct_to_block p b :: acc in
   let last = block_struct_to_block p (List.hd bs) in
   let block = List.fold_left (add_block p) [last] (List.tl bs) in
@@ -2862,7 +2875,12 @@ let rec block_struct_to_block_quote p indent bs =
       let first = Block.meta (List.hd quote) and last = Block.meta last in
       Block.Blocks (quote, meta_of_metas p ~first ~last)
   in
-  Block.Block_quote ({indent; block}, Block.meta block)
+  let meta =
+    let marker_loc = textloc_of_span p marker in
+    let first_meta = meta p marker_loc in
+    meta_of_metas p ~first:first_meta ~last:(Block.meta block)
+  in
+  Block.Block_quote ({indent; block}, meta)
 
 and block_struct_to_footnote_definition p indent (label, defined_label) bs =
   let add_block p acc b = block_struct_to_block p b :: acc in
@@ -2947,7 +2965,8 @@ and block_struct_to_list p list =
   Block.List ({ type' = list.Block_struct.list_type; tight; items }, meta)
 
 and block_struct_to_block p = function
-| Block_struct.Block_quote (ind, bs) -> block_struct_to_block_quote p ind bs
+| Block_struct.Block_quote (ind, bs, marker) ->
+    block_struct_to_block_quote p ind marker bs
 | Block_struct.List list -> block_struct_to_list p list
 | Block_struct.Paragraph par -> block_struct_to_paragraph p par
 | Block_struct.Thematic_break (i, br) -> block_struct_to_thematic_break p i br

--- a/src/cmarkit.ml
+++ b/src/cmarkit.ml
@@ -1982,7 +1982,7 @@ module Block_struct = struct
     (* https://spec.commonmark.org/current/#block-quote-marker *)
     if end_of_line p || p.i.[p.current_char] <> '>' then Match.Nomatch else
     let marker_span =
-      current_line_span p ~first:p.current_char ~last:(p.current_char+1)
+      current_line_span p ~first:p.current_char ~last:p.current_char
     in
     let next_is_blank =
       let next = p.current_char + 1 in

--- a/src/cmarkit.ml
+++ b/src/cmarkit.ml
@@ -2060,7 +2060,7 @@ module Block_struct = struct
   type paragraph = { maybe_ref : bool; lines : line_span list }
 
   type t =
-  | Block_quote of Layout.indent * t list * line_span (* loc of initial marker *)
+  | Block_quote of Layout.indent * line_span (* loc of initial marker *) * t list
   | Blank_line of space_pad * line_span
   | Code_block of code_block
   | Heading of heading
@@ -2326,8 +2326,8 @@ module Block_struct = struct
       Html_block { h with end_cond = None } :: bs
 
   let rec end_doc p = function
-  | Block_quote (indent, bq, marker) :: bs ->
-      Block_quote (indent, end_doc p bq, marker) :: bs
+  | Block_quote (indent, marker, bq) :: bs ->
+      Block_quote (indent, marker, end_doc p bq) :: bs
   | List list :: bs -> close_list p list bs
   | Paragraph par :: bs -> close_paragraph p par bs
   | Code_block (`Indented ls) :: bs -> close_indented_code_block p ls bs
@@ -2419,7 +2419,7 @@ module Block_struct = struct
   | Match.Blank_line -> blank_line p :: bs
   | Indented_code_block_line -> indented_code_block p :: bs
   | Block_quote_line marker ->
-      Block_quote (indent, add_open_blocks p [], marker) :: bs
+      Block_quote (indent, marker, add_open_blocks p []) :: bs
   | Thematic_break_line last -> thematic_break p ~indent ~last :: bs
   | List_marker_line m -> list p ~indent m bs
   | Atx_heading_line (level, after_open, first_content, last_content) ->
@@ -2504,7 +2504,7 @@ module Block_struct = struct
     | Blank_line ->
         blank_line p :: close_paragraph p par bs
     | Block_quote_line marker ->
-        Block_quote (indent, add_open_blocks p [], marker)
+        Block_quote (indent, marker, add_open_blocks p [])
         :: (close_paragraph p par bs)
     | Setext_underline_line (level, last_underline) ->
         let bs = close_paragraph p par bs in
@@ -2576,10 +2576,10 @@ module Block_struct = struct
 
   let rec try_lazy_continuation p ~indent_start = function
   | Paragraph par :: bs -> Some (add_paragraph_line p ~indent_start par bs)
-  | Block_quote (indent, bq, marker) :: bs ->
+  | Block_quote (indent, marker, bq) :: bs ->
       begin match try_lazy_continuation p ~indent_start bq with
       | None -> None
-      | Some bq -> Some (Block_quote (indent, bq, marker) :: bs)
+      | Some bq -> Some (Block_quote (indent, marker, bq) :: bs)
       end
   | List l :: bs ->
       let i = List.hd l.items in
@@ -2605,19 +2605,19 @@ module Block_struct = struct
     let indent_start = p.current_char and indent = current_indent p in
     match match_line_type ~indent ~no_setext:true p with
     | Block_quote_line _ ->
-        Block_quote (indent_layout, add_line p bq, marker) :: bs
+        Block_quote (indent_layout, marker, add_line p bq) :: bs
     | (Indented_code_block_line (* Looks like a *) | Paragraph_line) as ltype ->
         begin match try_lazy_continuation p ~indent_start bq with
-        | Some bq -> Block_quote (indent_layout, bq, marker) :: bs
+        | Some bq -> Block_quote (indent_layout, marker, bq) :: bs
         | None ->
             let bs =
-              Block_quote (indent_layout, close_last_block p bq, marker) :: bs
+              Block_quote (indent_layout, marker, close_last_block p bq) :: bs
             in
             add_open_blocks_with_line_class p ~indent ~indent_start bs ltype
         end
     | ltype ->
         let bs =
-          Block_quote (indent_layout, close_last_block p bq, marker) :: bs
+          Block_quote (indent_layout, marker, close_last_block p bq) :: bs
         in
         add_open_blocks_with_line_class p ~indent ~indent_start bs ltype
 
@@ -2688,7 +2688,7 @@ module Block_struct = struct
   | List list :: bs -> try_add_to_list_item p list bs
   | Code_block (`Indented ls) :: bs -> try_add_to_indented_code_block p ls bs
   | Code_block (`Fenced f) :: bs -> try_add_to_fenced_code_block p f bs
-  | Block_quote (ind, bq, marker) :: bs -> try_add_to_block_quote p ind bq marker bs
+  | Block_quote (ind, marker, bq) :: bs -> try_add_to_block_quote p ind bq marker bs
   | Html_block html :: bs -> try_add_to_html_block p html bs
   | Ext_table (ind, rows) :: bs -> try_add_to_table p ind rows bs
   | Ext_footnote (i, l, blocks) :: bs -> try_add_to_footnote p i l blocks bs
@@ -2965,7 +2965,7 @@ and block_struct_to_list p list =
   Block.List ({ type' = list.Block_struct.list_type; tight; items }, meta)
 
 and block_struct_to_block p = function
-| Block_struct.Block_quote (ind, bs, marker) ->
+| Block_struct.Block_quote (ind, marker, bs) ->
     block_struct_to_block_quote p ind marker bs
 | Block_struct.List list -> block_struct_to_list p list
 | Block_struct.Paragraph par -> block_struct_to_paragraph p par

--- a/src/cmarkit_base.ml
+++ b/src/cmarkit_base.ml
@@ -1026,7 +1026,7 @@ type html_block_end_cond =
 type line_type =
 | Atx_heading_line of heading_level * byte_pos * first * last
 | Blank_line
-| Block_quote_line
+| Block_quote_line of line_span (* loc of marker *)
 | Fenced_code_block_line of first * last * (first * last) option
 | Html_block_line of html_block_end_cond
 | Indented_code_block_line

--- a/src/cmarkit_base.mli
+++ b/src/cmarkit_base.mli
@@ -301,7 +301,7 @@ type html_block_end_cond =
 type line_type =
 | Atx_heading_line of heading_level * byte_pos (* after # *) * first * last
 | Blank_line
-| Block_quote_line
+| Block_quote_line of line_span (* loc of marker *)
 | Fenced_code_block_line of first * last * (first * last) option
 | Html_block_line of html_block_end_cond
 | Indented_code_block_line

--- a/test/snapshots/basic.exts.locs
+++ b/test/snapshots/basic.exts.locs
@@ -1167,7 +1167,7 @@ File "basic.exts.md", lines 1-183
   Blank line:
   File "basic.exts.md", line 174
   Block quote:
-  File "basic.exts.md", lines 175-177, characters 2-21
+  File "basic.exts.md", lines 175-177, characters 0-21
     Table:
     File "basic.exts.md", lines 175-177, characters 2-21
       Separator line:

--- a/test/snapshots/basic.exts.nolayout.locs
+++ b/test/snapshots/basic.exts.nolayout.locs
@@ -1167,7 +1167,7 @@ File "basic.exts.md", lines 1-183
   Blank line:
   File "basic.exts.md", line 174
   Block quote:
-  File "basic.exts.md", lines 175-177, characters 2-21
+  File "basic.exts.md", lines 175-177, characters 0-21
     Table:
     File "basic.exts.md", lines 175-177, characters 2-21
       Separator line:

--- a/test/snapshots/basic.locs
+++ b/test/snapshots/basic.locs
@@ -97,7 +97,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 20
   Block quote:
-  File "basic.md", lines 21-24, characters 2-22
+  File "basic.md", lines 21-24, characters 0-22
     Paragraph:
     File "basic.md", lines 21-24, characters 2-22
       Inlines:
@@ -357,7 +357,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 57
   Block quote:
-  File "basic.md", lines 58-60, characters 2-18
+  File "basic.md", lines 58-60, characters 0-18
     Link reference definition:
     File "basic.md", lines 58-60, characters 2-18
       Label:
@@ -441,7 +441,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 72
   Block quote:
-  File "basic.md", lines 73-74, characters 3-58
+  File "basic.md", lines 73-74, characters 0-58
     Paragraph:
     File "basic.md", lines 73-74, characters 3-58
       Inlines:
@@ -493,9 +493,9 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 84
   Block quote:
-  File "basic.md", lines 85-88, characters 8-43
+  File "basic.md", lines 85-88, characters 2-43
     Block quote:
-    File "basic.md", lines 85-88, characters 8-43
+    File "basic.md", lines 85-88, characters 6-43
       Paragraph:
       File "basic.md", lines 85-88, characters 8-43
         Inlines:
@@ -535,7 +535,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 89
   Block quote:
-  File "basic.md", line 90, characters 3-19
+  File "basic.md", line 90, characters 0-19
     Heading, level 2:
     File "basic.md", line 90, characters 3-19
       Text:
@@ -547,7 +547,7 @@ File "basic.md", lines 1-195
     Text:
     File "basic.md", line 92, characters 2-29
   Block quote:
-  File "basic.md", line 93, characters 3-18
+  File "basic.md", line 93, characters 0-18
     Paragraph:
     File "basic.md", line 93, characters 3-18
       Text:
@@ -621,7 +621,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 120
   Block quote:
-  File "basic.md", lines 121-128, characters 2-9
+  File "basic.md", lines 121-128, characters 0-9
     Code block:
     File "basic.md", lines 121-128, characters 2-9
       Opening fence:
@@ -671,7 +671,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 136
   Block quote:
-  File "basic.md", lines 137-139, characters 2-10
+  File "basic.md", lines 137-139, characters 0-10
     Heading, level 2:
     File "basic.md", lines 137-139, characters 2-10
       Inlines:
@@ -793,7 +793,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 162
   Block quote:
-  File "basic.md", lines 163-164, characters 2-23
+  File "basic.md", lines 163-164, characters 0-23
     Blocks:
     File "basic.md", lines 163-164, characters 2-23
       Paragraph:
@@ -887,7 +887,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 177
   Block quote:
-  File "basic.md", lines 178-182, characters 4-9
+  File "basic.md", lines 178-182, characters 0-9
     Paragraph:
     File "basic.md", lines 178-182, characters 4-9
       Inlines:
@@ -951,7 +951,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 193
   Block quote:
-  File "basic.md", line 194, characters 3-10
+  File "basic.md", line 194, characters 0-10
     Thematic break:
     File "basic.md", line 194, characters 3-10
   Blank line:

--- a/test/snapshots/basic.nolayout.locs
+++ b/test/snapshots/basic.nolayout.locs
@@ -97,7 +97,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 20
   Block quote:
-  File "basic.md", lines 21-24, characters 2-22
+  File "basic.md", lines 21-24, characters 0-22
     Paragraph:
     File "basic.md", lines 21-24, characters 2-22
       Inlines:
@@ -357,7 +357,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 57
   Block quote:
-  File "basic.md", lines 58-60, characters 2-18
+  File "basic.md", lines 58-60, characters 0-18
     Link reference definition:
     File "basic.md", lines 58-60, characters 2-18
       Label:
@@ -441,7 +441,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 72
   Block quote:
-  File "basic.md", lines 73-74, characters 3-58
+  File "basic.md", lines 73-74, characters 0-58
     Paragraph:
     File "basic.md", lines 73-74, characters 3-58
       Inlines:
@@ -493,9 +493,9 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 84
   Block quote:
-  File "basic.md", lines 85-88, characters 8-43
+  File "basic.md", lines 85-88, characters 2-43
     Block quote:
-    File "basic.md", lines 85-88, characters 8-43
+    File "basic.md", lines 85-88, characters 6-43
       Paragraph:
       File "basic.md", lines 85-88, characters 8-43
         Inlines:
@@ -535,7 +535,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 89
   Block quote:
-  File "basic.md", line 90, characters 3-19
+  File "basic.md", line 90, characters 0-19
     Heading, level 2:
     File "basic.md", line 90, characters 3-19
       Text:
@@ -547,7 +547,7 @@ File "basic.md", lines 1-195
     Text:
     File "basic.md", line 92, characters 2-29
   Block quote:
-  File "basic.md", line 93, characters 3-18
+  File "basic.md", line 93, characters 0-18
     Paragraph:
     File "basic.md", line 93, characters 3-18
       Text:
@@ -621,7 +621,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 120
   Block quote:
-  File "basic.md", lines 121-128, characters 2-9
+  File "basic.md", lines 121-128, characters 0-9
     Code block:
     File "basic.md", lines 121-128, characters 2-9
       Opening fence:
@@ -671,7 +671,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 136
   Block quote:
-  File "basic.md", lines 137-139, characters 2-10
+  File "basic.md", lines 137-139, characters 0-10
     Heading, level 2:
     File "basic.md", lines 137-139, characters 2-10
       Inlines:
@@ -793,7 +793,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 162
   Block quote:
-  File "basic.md", lines 163-164, characters 2-23
+  File "basic.md", lines 163-164, characters 0-23
     Blocks:
     File "basic.md", lines 163-164, characters 2-23
       Paragraph:
@@ -887,7 +887,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 177
   Block quote:
-  File "basic.md", lines 178-182, characters 4-9
+  File "basic.md", lines 178-182, characters 0-9
     Paragraph:
     File "basic.md", lines 178-182, characters 4-9
       Inlines:
@@ -951,7 +951,7 @@ File "basic.md", lines 1-195
   Blank line:
   File "basic.md", line 193
   Block quote:
-  File "basic.md", line 194, characters 3-10
+  File "basic.md", line 194, characters 0-10
     Thematic break:
     File "basic.md", line 194, characters 3-10
   Blank line:


### PR DESCRIPTION
Previously, they did not include the initial marker:

In:

```markdown
> Hello
>
> Goodbye
```

the location of the block quote started at "`H`" instead of the first "`>`".
