### PR TITLE
Fix `Cmarkit_html.of_doc` ignoring its `backend_blocks` argument

### DIFF
--- a/src/cmarkit_html.ml
+++ b/src/cmarkit_html.ml
@@ -499,4 +499,4 @@ let xhtml_renderer ?backend_blocks ~safe () =
   Cmarkit_renderer.make ~init_context ~inline ~block ~doc ()
 
 let of_doc ?backend_blocks ~safe d =
-  Cmarkit_renderer.doc_to_string (renderer ~safe ()) d
+  Cmarkit_renderer.doc_to_string (renderer ?backend_blocks ~safe ()) d


### PR DESCRIPTION
A very simple fix: it looks like the `backend_argument` (for rendering `=html` code blocks as html) in the html render was not propagated from `of_doc` to `renderer`.

As a result, the arg was ignored (and in effect `false` was always passed to `render`).